### PR TITLE
fix option not usable as documented

### DIFF
--- a/lib/primus-locky.js
+++ b/lib/primus-locky.js
@@ -46,7 +46,7 @@ function PrimusLocky(primus, options) {
 
   // Define a heartbeat to refresh locks.
   // By default TTL - 1s.
-  var heartbeatIntervalTime = options.heartbeatInterval || options.locky.client.ttl - 1000;
+  var heartbeatIntervalTime = options.locky.heartbeatInterval || options.locky.client.ttl - 1000;
   var heartbeatInterval = setInterval(this.refreshLocks.bind(this), heartbeatIntervalTime);
   this.primus.on('close', function onClose() {
     clearInterval(heartbeatInterval);


### PR DESCRIPTION
cf README.md doc for setting `heartbeatInterval` :

```js
new Primus(server, {
  locky: {
    heartbeatInterval: 2000
  }
});
```

`heartbeatInterval` is accessible via `options.locky.heartbeatInterval`, not via `options.heartbeatInterval`