### PR TITLE
Log only if necessary

### DIFF
--- a/lib/primus-locky.js
+++ b/lib/primus-locky.js
@@ -100,8 +100,10 @@ class PrimusLocky {
         }
 
         // If the locker is the current user, refresh the lock.
-        this.primus.emit('refreshLock', resource, room, spark, locker);
-        if (user === locker) this.locky.refresh(resource);
+        if (user === locker) {
+          this.primus.emit('refreshLock', resource, room, spark, locker);
+          this.locky.refresh(resource);
+        }
       });
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primus-locky",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Primus locky is a primus plugin for locky, it provides a room based locking.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Génère trop de log de rafraichissement.
On loggue que si le user et le locket sont les mêmes, et donc qu'on déclenche réellement un refresh.